### PR TITLE
Add support for Go recovered panics

### DIFF
--- a/lib/fluent/plugin/exception_detector.rb
+++ b/lib/fluent/plugin/exception_detector.rb
@@ -94,7 +94,7 @@ module Fluent
     ].freeze
 
     GO_RULES = [
-      rule(:start_state, /\bpanic: /, :go_after_panic),
+      rule([:start_state, :go_after_panic], /\bpanic: /, :go_after_panic),
       rule(:start_state, /http: panic serving/, :go_goroutine),
       rule(:go_after_panic, /^$/, :go_goroutine),
       rule([:go_after_panic, :go_after_signal, :go_frame_1],

--- a/test/plugin/test_exception_detector.rb
+++ b/test/plugin/test_exception_detector.rb
@@ -262,6 +262,30 @@ net/http.(*conn).serve(0xc00007eaa0, 0x12f10a0, 0xc00008a780)
 created by net/http.(*Server).Serve
 	/usr/local/go/src/net/http/server.go:2851 +0x2f5
 END
+
+  GO_RECOVERED = <<END.freeze
+panic: foo [recovered]
+	panic: foo [recovered]
+	panic: foo [recovered]
+	panic: foo
+
+goroutine 1 [running]:
+main.recoverAndPanic()
+	/tmp/sandbox1820875720/prog.go:12 +0x34
+panic({0x459120, 0x476600})
+	/usr/local/go-faketime/src/runtime/panic.go:838 +0x207
+main.recoverAndPanic()
+	/tmp/sandbox1820875720/prog.go:12 +0x34
+panic({0x459120, 0x476600})
+	/usr/local/go-faketime/src/runtime/panic.go:838 +0x207
+main.recoverAndPanic()
+	/tmp/sandbox1820875720/prog.go:12 +0x34
+panic({0x459120, 0x476600})
+	/usr/local/go-faketime/src/runtime/panic.go:838 +0x207
+main.main()
+	/tmp/sandbox1820875720/prog.go:7 +0x5d
+END
+
   CSHARP_EXC = <<END.freeze
 System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2[System.String,System.Collections.Generic.Dictionary`2[System.Int32,System.Double]].get_Item (System.String key) [0x00000] in <filename unknown>:0
@@ -635,6 +659,7 @@ END
     check_exception(GO_ON_GAE_EXC, false)
     check_exception(GO_SIGNAL_EXC, false)
     check_exception(GO_HTTP, false)
+    check_exception(GO_RECOVERED, false)
   end
 
   def test_ruby


### PR DESCRIPTION
When Go panic is recovered and thrown again it duplicates the first line of panic suffixed with `[recovered]`. The finite automaton is currently unable to recognise this panic output.

```
panic: foo [recovered]
	panic: foo [recovered]
	panic: foo [recovered]
	panic: foo

goroutine 1 [running]:
main.recoverAndPanic()
	/tmp/sandbox1820875720/prog.go:12 +0x34
panic({0x459120, 0x476600})
	/usr/local/go-faketime/src/runtime/panic.go:838 +0x207
main.recoverAndPanic()
	/tmp/sandbox1820875720/prog.go:12 +0x34
panic({0x459120, 0x476600})
	/usr/local/go-faketime/src/runtime/panic.go:838 +0x207
main.recoverAndPanic()
	/tmp/sandbox1820875720/prog.go:12 +0x34
panic({0x459120, 0x476600})
	/usr/local/go-faketime/src/runtime/panic.go:838 +0x207
main.main()
	/tmp/sandbox1820875720/prog.go:7 +0x5d
```

The output is produced by [following code](https://go.dev/play/p/MYwG9a_KcBg?v=goprev):
```
package main

func main() {
	defer recoverAndPanic()
	defer recoverAndPanic()
	defer recoverAndPanic()
	panic("foo")
}

func recoverAndPanic() {
	if r := recover(); r != nil {
		panic(r)
	}
}
```

BTW I have created the same PR also for the upstream repo https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions/pull/98